### PR TITLE
fix: Fixed user creation

### DIFF
--- a/cli/user.go
+++ b/cli/user.go
@@ -89,14 +89,14 @@ func CreateUser(cmd *cobra.Command, args []string) {
 	}
 
 	database := db.InitDB()
-	user := db.User{
+	user := &db.User{
 		FirstName: firstName,
 		LastName:  lastName,
 		Email:     email,
 		Password:  hashedPassword,
 	}
 
-	if err := database.Create(&user).Error; err != nil {
+	if err := db.CreateUser(database, user); err != nil {
 		log.Printf("Failed to create user: %v\n", err)
 		return
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -66,6 +66,7 @@ func GetUserByEmail(db *gorm.DB, email string) (*User, error) {
 }
 
 func CreateUser(db *gorm.DB, user *User) error {
+	user.SessionToken = nil // Explicitly set to nil for new users
 	return db.Create(user).Error
 }
 
@@ -92,7 +93,7 @@ func UpdateUserSessionToken(db *gorm.DB, user *User) error {
 	if err != nil {
 		return err
 	}
-	user.SessionToken = token
+	user.SessionToken = &token
 	return db.Save(user).Error
 }
 

--- a/db/db_types.go
+++ b/db/db_types.go
@@ -29,5 +29,5 @@ type User struct {
 	LastName     string
 	Email        string `gorm:"uniqueIndex"`
 	Password     string
-	SessionToken string `gorm:"uniqueIndex"`
+	SessionToken *string `gorm:"uniqueIndex"` // Changed to pointer to allow NULL
 }

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -40,7 +40,7 @@ func (h *AuthHandlers) Login(c *gin.Context) {
 		return
 	}
 
-	c.SetCookie("session", user.SessionToken, 3600*24, "/", "", false, true)
+	c.SetCookie("session", *user.SessionToken, 3600*24, "/", "", false, true)
 
 	// Redirect to original destination
 	c.Redirect(http.StatusFound, returnTo)

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -20,7 +20,7 @@ func AuthRequired(database *gorm.DB) gin.HandlerFunc {
 		}
 
 		user, err := db.GetUserByToken(database, token)
-		if err != nil {
+		if err != nil || user.SessionToken == nil {
 			c.SetCookie("session", "", -1, "/", "", false, true)
 			// Store requested URL and redirect to login
 			returnTo := c.Request.URL.String()

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -15,10 +15,11 @@ func TestAuthRequired(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
+	token := "valid-token"
 	// Create test user with session
 	user := &db.User{
 		Email:        "test@example.com",
-		SessionToken: "valid-token",
+		SessionToken: &token,
 	}
 	database.Create(user)
 


### PR DESCRIPTION
Creating two users one after the other fails because the session value is empty and has a unique constraint